### PR TITLE
Creepy compiles as well with Clang than GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ INCDIR		:= ./include/
 #
 # Compilation & link options
 #
-CC		:= gcc
+CC		:= cc
 CFLAGS		:= -W -Wall -Wextra -pedantic -I $(INCDIR) -std=c99 -g3
 LDLIBS		:= -lcurl
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Creepy is a packet manager for Entropy, a mobile operating system.
 To build Creepy, you need :
 * A linux-base system. Currently, Windows and Mac OS X are not supported.
 * The [libcurl](https://curl.haxx.se/libcurl/) library
-* GCC
+* GCC or Clang
 * Make
 
 # Building Creepy


### PR DESCRIPTION
In the Makefile, I have replaced `gcc` by `cc`, which is the default C compiler.
