### PR TITLE
Improved error management

### DIFF
--- a/include/arguments.h
+++ b/include/arguments.h
@@ -15,13 +15,16 @@
 
 /* Arguments parsing functions */
 
+/*
+** Returns 0 on success, -1 on error
+*/
 int		arguments_parse(t_creepy *, t_params *, int, char *[]);
 bool		arguments_parse_operation(t_params *, int, bool);
 int		arguments_parse_sync(t_params *params, int opt);
 
 /* Utils functions */
 
-void		arguments_usage(t_creepy *, t_operation, char *);
+void		arguments_usage(t_operation, char *);
 void		arguments_version(t_creepy *);
 bool		arguments_needs_root(t_params *params);
 

--- a/include/creepy.h
+++ b/include/creepy.h
@@ -41,8 +41,8 @@ typedef enum		e_operation
 
 typedef struct		s_repository
 {
-  char			*name;
-  char			*url;
+  const char            *name;
+  const char            *url;
   struct s_repository	*next;
 }			t_repository;
 
@@ -63,13 +63,33 @@ typedef struct
   t_repository		*repo;
 }			t_creepy;
 
-bool			init(t_creepy *);
+/*
+** Returns -1 on error, 0 on success.
+**
+** A description of the error is printed on the error output.
+** On error, the t_creepy must not be invalidated with cleanup().
+*/
+int			init(t_creepy *creepy);
 
 /* Utils functions */
 
+/*
+** Prints an error message.
+*/
 void			print_error(const char *err, ...);
-int			print_errori(const char *err, ...);
-void			*print_errorn(const char *err, ...);
-void			cleanup(t_creepy *, int ret);
+
+/*
+** Frees the ressources allocated in the given t_creepy.
+**
+** Invalidate the t_creepy.
+*/
+void			cleanup(t_creepy *creepy);
+
+/*
+** Prints the error message and exits with a non-zero status.
+**
+** Use only in case of fatal error.
+*/
+void    die(const char *error_message, ...) __attribute__ ((noreturn));
 
 #endif /* !CREEPY_H_ */

--- a/include/download.h
+++ b/include/download.h
@@ -22,7 +22,10 @@ typedef struct		s_ftp_file
   bool			print_once;
 }			t_ftp_file;
 
-bool			download_file(t_creepy *,
+/*
+** Returns -1 on error, 0 on success.
+*/
+int			download_file(t_creepy *,
 				      const char *u,
 				      const char *p,
 				      const char *print_name);

--- a/include/operation_sync.h
+++ b/include/operation_sync.h
@@ -13,6 +13,9 @@
 
 # include "operation.h"
 
-bool		operation_sync_refresh(t_creepy *);
+/*
+** Returns 0 on success, -1 on error
+*/
+int		operation_sync_refresh(t_creepy *);
 
 #endif /* !OPERATION_SYNC_H_ */

--- a/include/repository.h
+++ b/include/repository.h
@@ -13,6 +13,9 @@
 
 # include "creepy.h"
 
-bool			repository_create_main_dir(t_repository *rep);
+/*
+** Returns 0 on success, -1 on error.
+*/
+int			repository_create_main_dir(t_repository *rep);
 
 #endif /* !REPOSITORY_H_ */

--- a/source/arguments/arguments_parse.c
+++ b/source/arguments/arguments_parse.c
@@ -43,33 +43,38 @@ int			arguments_parse(t_creepy *creepy, t_params *params,
     }
 
   if (params->op == 0)
-    return (print_errori("Only one operation may be used at a time"));
+    {
+      print_error("Only one operation may be used at a time");
+      return (-1);
+    }
   if (params->help) {
-      arguments_usage(creepy, params->op, argv[0]);
-      cleanup(creepy, 0);
-    }
+    arguments_usage(params->op, argv[0]);
+    return (0);
+  }
   if (params->version) {
-      arguments_version(creepy);
-      cleanup(creepy, 0);
-    }
+    arguments_version(creepy);
+    return (0);
+  }
 
   //Parse operations parameters. (Like the -r in -Sr)
   optind = 1;
-  while ((opt = getopt_long(argc, argv, optstring, opts, &option_index)) != (-1))
+  while ((opt = getopt_long(argc, argv, optstring, opts, &option_index)) != -1)
     {
       if (opt == '?')
 	return (1);
       else if (opt == 0 || arguments_parse_operation(params, opt, true) == 0)
 	continue;
+
       switch (creepy->params.op)
 	{
-	  case OP_SYNC:
-	    result = arguments_parse_sync(&creepy->params, opt);
-	    break;
-	  default:
-	    result = 1;
-	    break;
+        case OP_SYNC:
+          result = arguments_parse_sync(&creepy->params, opt);
+          break;
+        default:
+          result = 1;
+          break;
 	}
+
       if (result != 0) //The flag exists, but it's not in the actual operation.
 	{
 	  if(opt < FLAG_MINIMAL)

--- a/source/arguments/arguments_usage.c
+++ b/source/arguments/arguments_usage.c
@@ -36,8 +36,7 @@ void			arguments_usage_list(char *argv0)
   printf("usage: %s {-L --list} [options] <package(s)>\n", argv0);
 }
 
-void			arguments_usage(t_creepy *creepy,
-					t_operation op,
+void			arguments_usage(t_operation op,
 					char *argv0)
 {
   if (op == OP_SYNC)
@@ -48,5 +47,4 @@ void			arguments_usage(t_creepy *creepy,
     arguments_usage_list(argv0);
   else
     arguments_usage_general(argv0);
-  cleanup(creepy, 0);
 }

--- a/source/arguments/arguments_version.c
+++ b/source/arguments/arguments_version.c
@@ -12,6 +12,7 @@
 
 void			arguments_version(t_creepy *creepy)
 {
+  (void)creepy;
   printf("Creepy v%s\n", CREEPY_VERSION_STR);
   printf("Copyright (C) 2016 - Creepy and Entropy development team\n");
 }

--- a/source/arguments/arguments_version.c
+++ b/source/arguments/arguments_version.c
@@ -14,5 +14,4 @@ void			arguments_version(t_creepy *creepy)
 {
   printf("Creepy v%s\n", CREEPY_VERSION_STR);
   printf("Copyright (C) 2016 - Creepy and Entropy development team\n");
-  cleanup(creepy, 0);
 }

--- a/source/init.c
+++ b/source/init.c
@@ -12,17 +12,20 @@
 #include <string.h>
 #include "creepy.h"
 
-bool			init(t_creepy *creepy)
+int			init(t_creepy *creepy)
 {
   struct stat		st;
 
   memset(creepy, 0, sizeof(t_creepy));
 
-  //Main creepy directory
+  // Main creepy directory
   if (stat(CREEPY_PATH, &st) == -1 && mkdir(CREEPY_PATH, 0755) != 0)
-    return (print_errori("Can't create creepy main directory \""CREEPY_PATH"\"\n"));
+    {
+      print_error("Can't create creepy main directory \"" CREEPY_PATH "\"\n");
+      return (-1);
+    }
 
-  //Curl initialisation
+  // Curl initialisation
   curl_global_init(CURL_GLOBAL_ALL);
 
   return (false);

--- a/source/init.c
+++ b/source/init.c
@@ -28,5 +28,5 @@ int			init(t_creepy *creepy)
   // Curl initialisation
   curl_global_init(CURL_GLOBAL_ALL);
 
-  return (false);
+  return (0);
 }

--- a/source/main.c
+++ b/source/main.c
@@ -15,49 +15,79 @@
 #include "arguments.h"
 #include "operation.h"
 
+static int      do_operation(t_creepy *creepy)
+{
+  int           ret = 0;
+  switch (creepy->params.op)
+    {
+    case OP_SYNC:
+      ret = operation_sync(creepy);
+      break;
+    case OP_REMOVE:
+      ret = operation_remove(creepy);
+      break;
+    case OP_LIST:
+      ret = operation_list(creepy);
+      break;
+    default:
+      print_error("no operation specified (use -h for help)\n");
+      return (-1);
+    }
+  return (ret);
+}
+
+/*
+** Returns a repository or NULL on error.
+*/
+static t_repository     *create_repo(void)
+{
+  t_repository *repo = malloc(sizeof(t_repository));
+  if (repo == NULL)
+    {
+      return (NULL);
+    }
+
+  repo->name = "Creepy_Official_Repository";
+  repo->url = "http://download.thinkbroadband.com/5MB.zip";
+  repo->next = NULL;
+  return repo;
+}
+
 int			main(int argc, char *argv[])
 {
   t_creepy		creepy;
-  int			ret;
   int			myuid = getuid();
 
   if (init(&creepy))
-    cleanup(&creepy, EXIT_FAILURE); //This calls exit()
+    return EXIT_FAILURE;
 
-  //TODO : Add auto-loading of repositories instead of this debug-list.
-  t_repository *repo = calloc(sizeof(t_repository), 1);
+  // TODO: Add auto-loading of repositories instead of this debug-list.
+  t_repository *repo = create_repo();
   if (repo == NULL)
-    cleanup(&creepy, EXIT_FAILURE);
-  repo->name = "Creepy_Official_Repository";
-  repo->url = "http://download.thinkbroadband.com/5MB.zip";
+    {
+      print_error("Failed to create the default repository\n");
+      goto cleanup_creepy_error;
+    }
   creepy.repo = repo;
-  //ENDTODO
 
-  ret = arguments_parse(&creepy, &creepy.params, argc, argv);
-  if (ret != 0)
-    cleanup(&creepy, ret);
+  if (arguments_parse(&creepy, &creepy.params, argc, argv) != 0)
+    {
+      goto cleanup_creepy_error;
+    }
 
   if (myuid > 0 && arguments_needs_root(&creepy.params))
     {
       print_error("you need to be root to perform this operation\n");
-      cleanup(&creepy, 1);
+      goto cleanup_creepy_error;
     }
 
-  switch (creepy.params.op)
-    {
-      case OP_SYNC:
-        ret = operation_sync(&creepy);
-        break;
-      case OP_REMOVE:
-        ret = operation_remove(&creepy);
-        break;
-      case OP_LIST:
-        ret = operation_list(&creepy);
-        break;
-      default:
-      print_error("no operation specified (use -h for help)\n");
-      ret = EXIT_FAILURE;
-    }
-  cleanup(&creepy, ret);
-  return (EXIT_SUCCESS); /* Not reached */
+  if (do_operation(&creepy) != 0 )
+    goto cleanup_creepy_error;
+
+  cleanup(&creepy);
+  return EXIT_SUCCESS;
+
+ cleanup_creepy_error:
+  cleanup(&creepy);
+  return EXIT_FAILURE;
 }

--- a/source/operation/sync/operation_sync_refresh.c
+++ b/source/operation/sync/operation_sync_refresh.c
@@ -15,15 +15,14 @@
 #include "repository.h"
 #include "download.h"
 
-static char		*get_packagelist_filename(t_creepy *creepy,
-						  t_repository *repo)
+static char		*get_packagelist_filename(t_repository *repo)
 {
   char			*path;
 
   asprintf(&path, CREEPY_PATH"/%s/package_list", repo->name);
   if (!path)
     {
-      die("Asprintf failed (Not enough memory ?)\n");
+      die("asprintf() failed (Not enough memory ?)\n");
     }
   return (path);
 }
@@ -39,7 +38,7 @@ int			operation_sync_refresh(t_creepy *creepy)
       if (repository_create_main_dir(repo))
 	return (-1);
 
-      dest_path = get_packagelist_filename(creepy, repo);
+      dest_path = get_packagelist_filename(repo);
 
       for (int i = 0; i < 3; i++)
       if (download_file(creepy, repo->url, dest_path, repo->name))

--- a/source/operation/sync/operation_sync_refresh.c
+++ b/source/operation/sync/operation_sync_refresh.c
@@ -23,8 +23,7 @@ static char		*get_packagelist_filename(t_creepy *creepy,
   asprintf(&path, CREEPY_PATH"/%s/package_list", repo->name);
   if (!path)
     {
-      print_error("Asprintf failed (Not enough memory ?)\n");
-      cleanup(creepy, 1);
+      die("Asprintf failed (Not enough memory ?)\n");
     }
   return (path);
 }
@@ -38,17 +37,18 @@ bool			operation_sync_refresh(t_creepy *creepy)
   while (repo)
     {
       if (repository_create_main_dir(repo))
-	return (true);
+	return (-1);
 
       dest_path = get_packagelist_filename(creepy, repo);
 
       for (int i = 0; i < 3; i++)
       if (download_file(creepy, repo->url, dest_path, repo->name))
 	{
-	  return (print_errori("Failed while trying to refresh "
-			       "repository \"%s\"\n", repo->name));
+	  print_error("Failed while trying to refresh "
+                      "repository \"%s\"\n", repo->name);
+          return (-1);
 	}
       repo = repo->next;
     }
-  return (false);
+  return (0);
 }

--- a/source/operation/sync/operation_sync_refresh.c
+++ b/source/operation/sync/operation_sync_refresh.c
@@ -28,7 +28,7 @@ static char		*get_packagelist_filename(t_creepy *creepy,
   return (path);
 }
 
-bool			operation_sync_refresh(t_creepy *creepy)
+int			operation_sync_refresh(t_creepy *creepy)
 {
   t_repository		*repo;
   char			*dest_path;

--- a/source/repository/repository_main_dir.c
+++ b/source/repository/repository_main_dir.c
@@ -13,15 +13,18 @@
 #include <string.h>
 #include "repository.h"
 
-bool			repository_create_main_dir(t_repository *repo)
+int			repository_create_main_dir(t_repository *repo)
 {
   struct stat		st;
   char			*path;
 
   asprintf(&path, CREEPY_PATH"/%s", repo->name);
   if (!path)
-    return (true);
+    die("asprint() failure");
   if (stat(path, &st) == -1 && mkdir(path, 0755) != 0)
-    return (print_errori("Can't create directory \"%s\"\n", path));
-  return (false);
+    {
+      print_error("Can't create directory \"%s\"\n", path);
+      return -1;
+    }
+  return 0;
 }

--- a/source/utils/utils_cleanup.c
+++ b/source/utils/utils_cleanup.c
@@ -11,11 +11,10 @@
 #include <stdlib.h>
 #include "creepy.h"
 
-void			cleanup(t_creepy *creepy, int ret)
+void			cleanup(t_creepy *creepy)
 {
   /*
   ** TODO : Free ressources.
   */
   (void)creepy;
-  exit(ret);
 }

--- a/source/utils/utils_error.c
+++ b/source/utils/utils_error.c
@@ -10,33 +10,24 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include "creepy.h"
 
-void			print_error(const char *err, ...)
+void            print_error(const char *error_message, ...)
 {
-  va_list		va;
+  va_list       va;
 
-  va_start(va, err);
-  vfprintf(stderr, err, va);
+  va_start(va, error_message);
+  vfprintf(stderr, error_message, va);
   va_end(va);
 }
 
-int			print_errori(const char *err, ...)
+void            die(const char *error_message, ...)
 {
-  va_list		va;
+  va_list       va;
 
-  va_start(va, err);
-  vfprintf(stderr, err, va);
+  va_start(va, error_message);
+  vfprintf(stderr, error_message, va);
   va_end(va);
-  return (1);
-}
-
-void			*print_errorn(const char *err, ...)
-{
-  va_list		va;
-
-  va_start(va, err);
-  vfprintf(stderr, err, va);
-  va_end(va);
-  return (NULL);
+  exit(1);
 }


### PR DESCRIPTION
Removed print_error*() functions

Functions subject to fail returns ints instead of bools (0 on success and -1 on error)

The t_creepy instance is freed in the main() function only

Add die() functions to abort the execution on fatal error

Now, the cleanup() function does not exit the program
